### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: build
 on:
   push:
@@ -13,23 +14,11 @@ on:
     - "**"
   workflow_dispatch: {}
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   PROVIDER: lambda-builders
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-  NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
   PYPI_USERNAME: __token__
-  PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
-  PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-  PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-  SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
-  SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
-  SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   GOVERSION: 1.21.x
   NODEVERSION: 20.x
   PYTHONVERSION: "3.11"
@@ -40,11 +29,19 @@ env:
   AWS_REGION: us-west-2
   PULUMI_TEST_OWNER: moolumi
   GOLANGCI_LINT_VERSION: v1.55.2
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN,PULUMI_ACCESS_TOKEN,NPM_TOKEN,NODE_AUTH_TOKEN=NPM_TOKEN,NUGET_PUBLISH_KEY,PYPI_PASSWORD=PYPI_API_TOKEN,SLACK_WEBHOOK_URL,PUBLISH_REPO_USERNAME=OSSRH_USERNAME,PUBLISH_REPO_PASSWORD=OSSRH_PASSWORD,SIGNING_KEY_ID=JAVA_SIGNING_KEY_ID,SIGNING_KEY=JAVA_SIGNING_KEY,SIGNING_PASSWORD=JAVA_SIGNING_PASSWORD
 jobs:
   prerequisites:
     runs-on: ubuntu-latest
     name: prerequisites
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -83,7 +80,7 @@ jobs:
 
         echo 'EOF' >> $GITHUB_ENV
       env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2
@@ -92,8 +89,7 @@ jobs:
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
-        github.actor == 'pulumi-bot'
+    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') && github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@v1.1.0
       with:
@@ -124,7 +120,7 @@ jobs:
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
       env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -139,6 +135,9 @@ jobs:
         - java
     name: build_sdks
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -188,8 +187,7 @@ jobs:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}
     - name: UnTar provider binaries
-      run: mkdir -p ${{ github.workspace}}/bin && tar -zxf ${{ github.workspace }}/provider.tar.gz -C ${{
-        github.workspace}}/bin
+      run: mkdir -p ${{ github.workspace}}/bin && tar -zxf ${{ github.workspace }}/provider.tar.gz -C ${{ github.workspace}}/bin
     - name: Restore Binary Permissions
       run: chmod +x bin/*
     - name: Generate SDK
@@ -232,6 +230,9 @@ jobs:
       contents: read
       id-token: write
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -281,8 +282,7 @@ jobs:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}
     - name: UnTar provider binaries
-      run: mkdir -p ${{ github.workspace}}/bin && tar -zxf ${{ github.workspace }}/provider.tar.gz -C ${{
-        github.workspace}}/bin
+      run: mkdir -p ${{ github.workspace}}/bin && tar -zxf ${{ github.workspace }}/provider.tar.gz -C ${{ github.workspace}}/bin
     - name: Restore Binary Permissions
       run: chmod +x bin/*
     - name: Download SDK
@@ -291,8 +291,7 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{ github.workspace}}/sdk/${{ matrix.language}}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -317,7 +316,7 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         role-duration-seconds: 3600
         role-session-name: ${{ env.PROVIDER }}@githubActions
-        role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+        role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
     - name: Run tests
       run: >-
         set -euo pipefail
@@ -328,6 +327,9 @@ jobs:
     needs: test
     name: publish
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -357,18 +359,16 @@ jobs:
         role-duration-seconds: 7200
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-external-id: upload-pulumi-release
-        role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
+        role-to-assume: ${{ steps.esc-secrets.outputs.AWS_UPLOAD_ROLE_ARN }}
     - name: Download provider binary
       uses: actions/download-artifact@v4
       with:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}
     - name: Untar provider binaries
-      run: mkdir -p ${{ github.workspace }}/bin && tar -zxf ${{ github.workspace }}/provider.tar.gz -C ${{ github.workspace
-        }}/bin
+      run: mkdir -p ${{ github.workspace }}/bin && tar -zxf ${{ github.workspace }}/provider.tar.gz -C ${{ github.workspace }}/bin
     - name: Restore binary perms
-      run: find ${{ github.workspace }}/bin -name "pulumi-*-${{ env.PROVIDER }}" -print
-        -exec chmod +x {} \;
+      run: find ${{ github.workspace }}/bin -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
     - name: Test provider
       run: make test_provider
     - name: Create Provider Binaries
@@ -380,6 +380,9 @@ jobs:
     needs: publish
     name: publish_sdk
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -425,30 +428,27 @@ jobs:
         name: python-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
+      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C ${{github.workspace}}/sdk/python
     - name: Download dotnet SDK
       uses: actions/download-artifact@v4
       with:
         name: dotnet-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
+      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C ${{github.workspace}}/sdk/dotnet
     - name: Download nodejs SDK
       uses: actions/download-artifact@v4
       with:
         name: nodejs-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
+      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
   publish_java_sdk:
     runs-on: ubuntu-latest
@@ -456,6 +456,9 @@ jobs:
     needs: publish
     name: publish_java_sdk
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -492,8 +495,7 @@ jobs:
         name: java-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C ${{github.workspace}}/sdk/java
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
       env:
@@ -505,6 +507,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -522,5 +527,4 @@ jobs:
         args: -c ../.golangci.yml
         working-directory: provider
     name: lint
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: command-dispatch
 on:
   issue_comment:
@@ -5,23 +6,11 @@ on:
     - created
     - edited
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   PROVIDER: lambda-builders
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-  NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
   PYPI_USERNAME: __token__
-  PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
-  PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-  PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-  SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
-  SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
-  SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   GOVERSION: 1.21.x
   NODEVERSION: 20.x
   PYTHONVERSION: "3.11"
@@ -32,18 +21,26 @@ env:
   AWS_REGION: us-west-2
   PULUMI_TEST_OWNER: moolumi
   GOLANGCI_LINT_VERSION: v1.55.2
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN,PULUMI_ACCESS_TOKEN,NPM_TOKEN,NODE_AUTH_TOKEN=NPM_TOKEN,NUGET_PUBLISH_KEY,PYPI_PASSWORD=PYPI_API_TOKEN,SLACK_WEBHOOK_URL,PUBLISH_REPO_USERNAME=OSSRH_USERNAME,PUBLISH_REPO_PASSWORD=OSSRH_PASSWORD,SIGNING_KEY_ID=JAVA_SIGNING_KEY_ID,SIGNING_KEY=JAVA_SIGNING_KEY,SIGNING_PASSWORD=JAVA_SIGNING_PASSWORD
 jobs:
   command-dispatch-for-testing:
     runs-on: ubuntu-latest
     name: command-dispatch-for-testing
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
         lfs: true
     - uses: peter-evans/slash-command-dispatch@v2
       with:
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
+        token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
         reaction-token: ${{ secrets.GITHUB_TOKEN }}
         commands: run-acceptance-tests
         permission: write

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,24 +1,13 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: pull-request
 on:
   pull_request_target: {}
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   PROVIDER: lambda-builders
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-  NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
   PYPI_USERNAME: __token__
-  PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
-  PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-  PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-  SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
-  SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
-  SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   GOVERSION: 1.21.x
   NODEVERSION: 20.x
   PYTHONVERSION: "3.11"
@@ -29,11 +18,19 @@ env:
   AWS_REGION: us-west-2
   PULUMI_TEST_OWNER: moolumi
   GOLANGCI_LINT_VERSION: v1.55.2
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN,PULUMI_ACCESS_TOKEN,NPM_TOKEN,NODE_AUTH_TOKEN=NPM_TOKEN,NUGET_PUBLISH_KEY,PYPI_PASSWORD=PYPI_API_TOKEN,SLACK_WEBHOOK_URL,PUBLISH_REPO_USERNAME=OSSRH_USERNAME,PUBLISH_REPO_PASSWORD=OSSRH_PASSWORD,SIGNING_KEY_ID=JAVA_SIGNING_KEY_ID,SIGNING_KEY=JAVA_SIGNING_KEY,SIGNING_PASSWORD=JAVA_SIGNING_PASSWORD
 jobs:
   comment-on-pr:
     runs-on: ubuntu-latest
     name: comment-on-pr
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: release
 on:
   push:
@@ -5,23 +6,11 @@ on:
     - v*.*.*
     - "!v*.*.*-**"
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   PROVIDER: lambda-builders
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-  NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
   PYPI_USERNAME: __token__
-  PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
-  PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-  PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-  SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
-  SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
-  SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   GOVERSION: 1.21.x
   NODEVERSION: 20.x
   PYTHONVERSION: "3.11"
@@ -32,11 +21,19 @@ env:
   AWS_REGION: us-west-2
   PULUMI_TEST_OWNER: moolumi
   GOLANGCI_LINT_VERSION: v1.55.2
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN,PULUMI_ACCESS_TOKEN,NPM_TOKEN,NODE_AUTH_TOKEN=NPM_TOKEN,NUGET_PUBLISH_KEY,PYPI_PASSWORD=PYPI_API_TOKEN,SLACK_WEBHOOK_URL,PUBLISH_REPO_USERNAME=OSSRH_USERNAME,PUBLISH_REPO_PASSWORD=OSSRH_PASSWORD,SIGNING_KEY_ID=JAVA_SIGNING_KEY_ID,SIGNING_KEY=JAVA_SIGNING_KEY,SIGNING_PASSWORD=JAVA_SIGNING_PASSWORD
 jobs:
   prerequisites:
     runs-on: ubuntu-latest
     name: prerequisites
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -75,7 +72,7 @@ jobs:
 
         echo 'EOF' >> $GITHUB_ENV
       env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2
@@ -84,8 +81,7 @@ jobs:
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
-        github.actor == 'pulumi-bot'
+    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') && github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@v1.1.0
       with:
@@ -116,7 +112,7 @@ jobs:
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
       env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -131,6 +127,9 @@ jobs:
         - java
     name: build_sdks
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -180,8 +179,7 @@ jobs:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}
     - name: UnTar provider binaries
-      run: mkdir -p ${{ github.workspace}}/bin && tar -zxf ${{ github.workspace }}/provider.tar.gz -C ${{
-        github.workspace}}/bin
+      run: mkdir -p ${{ github.workspace}}/bin && tar -zxf ${{ github.workspace }}/provider.tar.gz -C ${{ github.workspace}}/bin
     - name: Restore Binary Permissions
       run: chmod +x bin/*
     - name: Generate SDK
@@ -223,6 +221,9 @@ jobs:
       contents: read
       id-token: write
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -272,8 +273,7 @@ jobs:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}
     - name: UnTar provider binaries
-      run: mkdir -p ${{ github.workspace}}/bin && tar -zxf ${{ github.workspace }}/provider.tar.gz -C ${{
-        github.workspace}}/bin
+      run: mkdir -p ${{ github.workspace}}/bin && tar -zxf ${{ github.workspace }}/provider.tar.gz -C ${{ github.workspace}}/bin
     - name: Restore Binary Permissions
       run: chmod +x bin/*
     - name: Download SDK
@@ -282,8 +282,7 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{ github.workspace}}/sdk/${{ matrix.language}}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -308,7 +307,7 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         role-duration-seconds: 3600
         role-session-name: ${{ env.PROVIDER }}@githubActions
-        role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+        role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
     - name: Run tests
       run: >-
         set -euo pipefail
@@ -319,6 +318,9 @@ jobs:
     needs: test
     name: publish
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -348,18 +350,16 @@ jobs:
         role-duration-seconds: 7200
         role-session-name: ${{ env.PROVIDER }}@githubActions
         role-external-id: upload-pulumi-release
-        role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
+        role-to-assume: ${{ steps.esc-secrets.outputs.AWS_UPLOAD_ROLE_ARN }}
     - name: Download provider binary
       uses: actions/download-artifact@v4
       with:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}
     - name: Untar provider binaries
-      run: mkdir -p ${{ github.workspace }}/bin && tar -zxf ${{ github.workspace }}/provider.tar.gz -C ${{ github.workspace
-        }}/bin
+      run: mkdir -p ${{ github.workspace }}/bin && tar -zxf ${{ github.workspace }}/provider.tar.gz -C ${{ github.workspace }}/bin
     - name: Restore binary perms
-      run: find ${{ github.workspace }}/bin -name "pulumi-*-${{ env.PROVIDER }}" -print
-        -exec chmod +x {} \;
+      run: find ${{ github.workspace }}/bin -name "pulumi-*-${{ env.PROVIDER }}" -print -exec chmod +x {} \;
     - name: Test provider
       run: make test_provider
     - name: Create Provider Binaries
@@ -371,6 +371,9 @@ jobs:
     needs: publish
     name: publish_sdks
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -416,30 +419,27 @@ jobs:
         name: python-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: Uncompress python SDK
-      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C
-        ${{github.workspace}}/sdk/python
+      run: tar -zxf ${{github.workspace}}/sdk/python.tar.gz -C ${{github.workspace}}/sdk/python
     - name: Download dotnet SDK
       uses: actions/download-artifact@v4
       with:
         name: dotnet-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: Uncompress dotnet SDK
-      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C
-        ${{github.workspace}}/sdk/dotnet
+      run: tar -zxf ${{github.workspace}}/sdk/dotnet.tar.gz -C ${{github.workspace}}/sdk/dotnet
     - name: Download nodejs SDK
       uses: actions/download-artifact@v4
       with:
         name: nodejs-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: Uncompress nodejs SDK
-      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C
-        ${{github.workspace}}/sdk/nodejs
+      run: tar -zxf ${{github.workspace}}/sdk/nodejs.tar.gz -C ${{github.workspace}}/sdk/nodejs
     - name: Install Twine
       run: python -m pip install pip twine
     - name: Publish SDKs
       run: ./ci-scripts/ci/publish-tfgen-package ${{ github.workspace }}
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        NODE_AUTH_TOKEN: ${{ steps.esc-secrets.outputs.NPM_TOKEN }}
         PYPI_PUBLISH_ARTIFACTS: all
   publish_java_sdk:
     runs-on: ubuntu-latest
@@ -447,6 +447,9 @@ jobs:
     needs: publish
     name: publish_java_sdk
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -483,8 +486,7 @@ jobs:
         name: java-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: Uncompress java SDK
-      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C
-        ${{github.workspace}}/sdk/java
+      run: tar -zxf ${{github.workspace}}/sdk/java.tar.gz -C ${{github.workspace}}/sdk/java
     - name: Publish Java SDK
       uses: gradle/gradle-build-action@v3
       env:
@@ -498,6 +500,9 @@ jobs:
     name: publish-go-sdk
     needs: publish_sdk
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -513,8 +518,7 @@ jobs:
         name: go-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: Uncompress go SDK
-      run: tar -zxf ${{github.workspace}}/sdk/go.tar.gz -C
-        ${{github.workspace}}/sdk/go
+      run: tar -zxf ${{github.workspace}}/sdk/go.tar.gz -C ${{github.workspace}}/sdk/go
     - name: Publish Go SDK
       uses: pulumi/publish-go-sdk-action@v1
       with:
@@ -532,13 +536,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish_go_sdk
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Install pulumictl
       uses: jaxxstorm/action-install-gh-release@v1.11.0
       with:
         repo: pulumi/pulumictl
     - name: Dispatch Event
-      run: pulumictl create docs-build pulumi-${{ env.PROVIDER }}
-        ${GITHUB_REF#refs/tags/}
+      run: pulumictl create docs-build pulumi-${{ env.PROVIDER }} ${GITHUB_REF#refs/tags/}
       env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     name: dispatch_docs_build

--- a/.github/workflows/run-acceptance-tests.yml
+++ b/.github/workflows/run-acceptance-tests.yml
@@ -1,3 +1,4 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: run-acceptance-tests
 on:
   repository_dispatch:
@@ -11,23 +12,11 @@ on:
     - CHANGELOG.md
   workflow_dispatch: {}
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   PROVIDER: lambda-builders
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-  NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
   PYPI_USERNAME: __token__
-  PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
-  PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-  PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-  SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
-  SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
-  SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   GOVERSION: 1.21.x
   NODEVERSION: 20.x
   PYTHONVERSION: "3.11"
@@ -39,20 +28,26 @@ env:
   PULUMI_TEST_OWNER: moolumi
   GOLANGCI_LINT_VERSION: v1.55.2
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN,PULUMI_ACCESS_TOKEN,NPM_TOKEN,NODE_AUTH_TOKEN=NPM_TOKEN,NUGET_PUBLISH_KEY,PYPI_PASSWORD=PYPI_API_TOKEN,SLACK_WEBHOOK_URL,PUBLISH_REPO_USERNAME=OSSRH_USERNAME,PUBLISH_REPO_PASSWORD=OSSRH_PASSWORD,SIGNING_KEY_ID=JAVA_SIGNING_KEY_ID,SIGNING_KEY=JAVA_SIGNING_KEY,SIGNING_PASSWORD=JAVA_SIGNING_PASSWORD
 jobs:
   comment-notification:
     runs-on: ubuntu-latest
     name: comment-notification
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Create URL to the run output
       id: vars
-      run: echo
-        run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-        >> "$GITHUB_OUTPUT"
+      run: echo run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID >> "$GITHUB_OUTPUT"
     - name: Update with Result
       uses: peter-evans/create-or-update-comment@v1
       with:
-        token: ${{ secrets.PULUMI_BOT_TOKEN }}
+        token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
         body: "Please view the PR build: ${{ steps.vars.outputs.run-url }}"
@@ -61,6 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     name: prerequisites
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -100,7 +98,7 @@ jobs:
 
         echo 'EOF' >> $GITHUB_ENV
       env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     - if: github.event_name == 'pull_request'
       name: Comment on PR with Details of Schema Check
       uses: thollander/actions-comment-pull-request@v2
@@ -109,8 +107,7 @@ jobs:
           ${{ env.SCHEMA_CHANGES }}
         comment_tag: schemaCheck
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') &&
-        github.actor == 'pulumi-bot'
+    - if: contains(env.SCHEMA_CHANGES, 'Looking good! No breaking changes found.') && github.actor == 'pulumi-bot'
       name: Add label if no breaking changes
       uses: actions-ecosystem/action-add-labels@v1.1.0
       with:
@@ -141,9 +138,8 @@ jobs:
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v4
       env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+        CODECOV_TOKEN: ${{ steps.esc-secrets.outputs.CODECOV_TOKEN }}
+    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
   build_sdks:
     needs: prerequisites
     runs-on: pulumi-ubuntu-8core
@@ -158,6 +154,9 @@ jobs:
         - java
     name: build_sdks
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -208,8 +207,7 @@ jobs:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}
     - name: UnTar provider binaries
-      run: mkdir -p ${{ github.workspace}}/bin && tar -zxf ${{ github.workspace }}/provider.tar.gz -C ${{
-        github.workspace}}/bin
+      run: mkdir -p ${{ github.workspace}}/bin && tar -zxf ${{ github.workspace }}/provider.tar.gz -C ${{ github.workspace}}/bin
     - name: Restore Binary Permissions
       run: chmod +x bin/*
     - name: Generate SDK
@@ -234,8 +232,7 @@ jobs:
         name: ${{ matrix.language  }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/${{ matrix.language }}.tar.gz
         retention-days: 30
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
   test:
     runs-on: pulumi-ubuntu-8core
     needs:
@@ -254,6 +251,9 @@ jobs:
       contents: read
       id-token: write
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -304,8 +304,7 @@ jobs:
         name: pulumi-${{ env.PROVIDER }}-provider.tar.gz
         path: ${{ github.workspace }}
     - name: UnTar provider binaries
-      run: mkdir -p ${{ github.workspace}}/bin && tar -zxf ${{ github.workspace }}/provider.tar.gz -C ${{
-        github.workspace}}/bin
+      run: mkdir -p ${{ github.workspace}}/bin && tar -zxf ${{ github.workspace }}/provider.tar.gz -C ${{ github.workspace}}/bin
     - name: Restore Binary Permissions
       run: chmod +x bin/*
     - name: Download SDK
@@ -314,8 +313,7 @@ jobs:
         name: ${{ matrix.language }}-sdk.tar.gz
         path: ${{ github.workspace}}/sdk/
     - name: UnTar SDK folder
-      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{
-        github.workspace}}/sdk/${{ matrix.language}}
+      run: tar -zxf ${{ github.workspace}}/sdk/${{ matrix.language}}.tar.gz -C ${{ github.workspace}}/sdk/${{ matrix.language}}
     - name: Update path
       run: echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Install Node dependencies
@@ -340,18 +338,20 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         role-duration-seconds: 3600
         role-session-name: ${{ env.PROVIDER }}@githubActions
-        role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+        role-to-assume: ${{ steps.esc-secrets.outputs.AWS_CI_ROLE_ARN }}
     - name: Run tests
       run: >-
         set -euo pipefail
 
         cd examples && go test -v -json -count=1 -cover -timeout 2h -tags=${{ matrix.language }} -parallel 4 . 2>&1 | tee /tmp/gotest.log | gotestfmt
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
   sentinel:
     runs-on: ubuntu-latest
     name: sentinel
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Mark workflow as successful
       uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76
       with:
@@ -360,14 +360,16 @@ jobs:
         state: success
         description: Sentinel checks passed
         sha: ${{ github.event.pull_request.head.sha || github.sha }}
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     needs:
     - test
     - lint
   lint:
     runs-on: ubuntu-latest
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -375,5 +377,4 @@ jobs:
         ref: ${{ env.PR_COMMIT_SHA }}
     # TODO: run some python linter
     name: lint
-    if: github.event_name == 'repository_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/weekly-pulumi-update.yml
+++ b/.github/workflows/weekly-pulumi-update.yml
@@ -1,26 +1,15 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
 name: weekly-pulumi-update
 on:
   schedule:
   - cron: 35 12 * * 4
   workflow_dispatch: {}
 env:
-  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   PROVIDER: kubernetes-cert-manager
-  PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   PULUMI_LOCAL_NUGET: ${{ github.workspace }}/nuget
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-  NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
   PYPI_USERNAME: __token__
-  PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   TRAVIS_OS_NAME: linux
-  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   PULUMI_GO_DEP_ROOT: ${{ github.workspace }}/..
-  PUBLISH_REPO_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-  PUBLISH_REPO_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-  SIGNING_KEY_ID: ${{ secrets.JAVA_SIGNING_KEY_ID }}
-  SIGNING_KEY: ${{ secrets.JAVA_SIGNING_KEY }}
-  SIGNING_PASSWORD: ${{ secrets.JAVA_SIGNING_PASSWORD }}
   GOVERSION: 1.21.x
   NODEVERSION: 20.x
   PYTHONVERSION: "3.11"
@@ -31,10 +20,18 @@ env:
   AWS_REGION: us-west-2
   PULUMI_TEST_OWNER: moolumi
   GOLANGCI_LINT_VERSION: v1.55.2
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: GITHUB_TOKEN=PULUMI_BOT_TOKEN,PULUMI_ACCESS_TOKEN,NPM_TOKEN,NODE_AUTH_TOKEN=NPM_TOKEN,NUGET_PUBLISH_KEY,PYPI_PASSWORD=PYPI_API_TOKEN,SLACK_WEBHOOK_URL,PUBLISH_REPO_USERNAME=OSSRH_USERNAME,PUBLISH_REPO_PASSWORD=OSSRH_PASSWORD,SIGNING_KEY_ID=JAVA_SIGNING_KEY_ID,SIGNING_KEY=JAVA_SIGNING_KEY,SIGNING_PASSWORD=JAVA_SIGNING_PASSWORD
 jobs:
   weekly-pulumi-update:
     runs-on: ubuntu-latest
     steps:
+    - name: Fetch secrets from ESC
+      id: esc-secrets
+      uses: pulumi/esc-action@v1
     - name: Checkout Repo
       uses: actions/checkout@v4
       with:
@@ -122,7 +119,7 @@ jobs:
         source_branch: update-pulumi/${{ github.run_id }}-${{ github.run_number }}
         destination_branch: master
         pr_title: Automated Pulumi/Pulumi upgrade
-        github_token: ${{ secrets.PULUMI_BOT_TOKEN }}
+        github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       env:
-        GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
     name: weekly-pulumi-update


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.
